### PR TITLE
Clarified timeout parameter, add client callback for managing jobs externally

### DIFF
--- a/truenas_api/truenas_api.go
+++ b/truenas_api/truenas_api.go
@@ -24,6 +24,7 @@ type Client struct {
 	notifyChan chan os.Signal               // For handling notifications (e.g., OS signals)
 	closeChan  chan struct{}                // Channel to signal when the connection should be closed
 	jobs       *Jobs                        // Jobs manager to track long-running jobs
+	jobsCb     func(int64, int64, map[string]interface{})
 }
 
 // Job represents a long-running job in TrueNAS.
@@ -140,6 +141,10 @@ func (c *Client) SubscribeToJobs() error {
 
 // NewClient creates a new WebSocket client connection.
 func NewClient(serverURL string, verifySSL bool) (*Client, error) {
+	return NewClientWithCallback(serverURL, verifySSL, nil)
+}
+
+func NewClientWithCallback(serverURL string, verifySSL bool, jobsCallback func(int64, int64, map[string]interface{})) (*Client, error) {
 	u, err := url.Parse(serverURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid URL: %w", err)
@@ -163,6 +168,7 @@ func NewClient(serverURL string, verifySSL bool) (*Client, error) {
 		pending:   make(map[int]chan json.RawMessage),
 		closeChan: make(chan struct{}),
 		jobs:      NewJobs(nil),
+		jobsCb:    jobsCallback,
 	}
 
 	client.jobs = NewJobs(client)
@@ -190,7 +196,9 @@ func (c *Client) Close() error {
 }
 
 // Call sends an RPC call to the server and waits for a response.
-func (c *Client) Call(method string, timeout time.Duration, params interface{}) (json.RawMessage, error) {
+func (c *Client) Call(method string, timeoutSeconds int64, params interface{}) (json.RawMessage, error) {
+	timeout := time.Duration(timeoutSeconds) * time.Second
+
 	c.mu.Lock()
 	c.callID++ // Increment callID for each call
 	callID := c.callID
@@ -221,7 +229,7 @@ func (c *Client) Call(method string, timeout time.Duration, params interface{}) 
 	select {
 	case res := <-responseChan:
 		return res, nil
-	case <-time.After(timeout * time.Second):
+	case <-time.After(timeout):
 		return nil, errors.New("call timed out")
 	}
 }
@@ -253,8 +261,18 @@ func (c *Client) listen() {
 				jobID := int64(params["id"].(float64))
 				fields := params["fields"].(map[string]interface{})
 
-				// Only handle jobs started by this client
-				if c.jobs.IsOwnedJob(jobID) {
+				if c.jobsCb != nil {
+					innerJobID := jobID
+					if innerMethod, _ := fields["method"].(string); innerMethod == "core.job_wait" {
+						if args, ok := fields["arguments"].([]interface{}); ok && len(args) > 0 {
+							if value, ok := args[0].(float64); ok {
+								innerJobID = int64(value)
+							}
+						}
+					}
+					c.jobsCb(jobID, innerJobID, fields)
+				} else if c.jobs.IsOwnedJob(jobID) {
+					// Only handle jobs started by this client
 					progress := fields["progress"].(map[string]interface{})
 					description, _ := progress["description"].(string)
 					percent, _ := progress["percent"].(float64)
@@ -310,11 +328,20 @@ func (c *Client) CallWithJob(method string, params interface{}, callback func(pr
 		return nil, fmt.Errorf("unexpected response format for job")
 	}
 
-	// Add the job to the Jobs manager
-	job := c.jobs.AddJob(int64(jobID), method)
+	var job *Job
+	if c.jobsCb != nil {
+		job = &Job{
+			ID:     int64(jobID),
+			Method: method,
+			State:  "PENDING",
+		}
+	} else {
+		// Add the job to the Jobs manager
+		job = c.jobs.AddJob(int64(jobID), method)
 
-	// Mark this job as owned by this client
-	c.jobs.AddOwnedJob(int64(jobID))
+		// Mark this job as owned by this client
+		c.jobs.AddOwnedJob(int64(jobID))
+	}
 
 	// Set the callback function for job updates
 	job.Callback = callback

--- a/truenas_go.go
+++ b/truenas_go.go
@@ -36,7 +36,7 @@ func main() {
 	serverURL := flag.String("uri", "", "WebSocket server URI (e.g., ws://localhost:6000/websocket)")
 	method := flag.String("method", "", "RPC method to call (e.g., core.ping)")
 	jsonArgs := flag.String("params", "[]", "JSON-formatted arguments for the method (e.g., '[\"param1\", \"param2\"]')")
-	timeout := flag.Int("timeout", 10, "Timeout in seconds for the call")
+	timeoutSecs := flag.Int("timeout", 10, "Timeout in seconds for the call")
 	verifySSL := flag.Bool("verifyssl", true, "Verify SSL certificates for wss:// connections")
 	jobFlag := flag.Bool("job", false, "Use CallWithJob for methods that return a job ID")
 	user := flag.String("U", "", "Username for login")
@@ -108,13 +108,13 @@ func main() {
 			jobResult := job.Result
 			fmt.Println("Job completed successfully. Result:")
 			printPrettyJSON(jobResult)
-		case <-time.After(time.Duration(*timeout) * time.Second):
-			log.Fatalf("Job timed out after %d seconds", *timeout)
+		case <-time.After(time.Duration(*timeoutSecs) * time.Second):
+			log.Fatalf("Job timed out after %d seconds", *timeoutSecs)
 		}
 	} else {
 		// Use the regular Call method
 		//fmt.Printf("Calling method '%s'...\n", *method)
-		response, err := client.Call(*method, time.Duration(*timeout), params)
+		response, err := client.Call(*method, int64(*timeoutSecs), params)
 		if err != nil {
 			log.Fatalf("RPC call failed: %v", err)
 		}


### PR DESCRIPTION
[From Golang's docs](https://pkg.go.dev/time#Duration):

> A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.

Duration wraps an int64, which makes it easy to pass numeric values as durations.

Unfortunately, this makes it easy to apply a duration that is measured in the wrong unit (ie. not nanoseconds).

To correctly represent a timeout value as a `time.Duration`, say 4.5 seconds, the underlying int64 value will be 4,500,000,000, since that's how many nanoseconds make up 4.5 seconds. When passing this value to `Call()`, however, the value is then multiplied by `time.Second`, resulting in a duration of approximately 142 years and 218 days.

This PR changes the definition of `Call()` such that the timeout parameter is an integer number of seconds, which is then converted into a timeout value. This way, code that depends on the current behaviour is still correct, however users are now made aware that the timeout value must be measured in seconds.

Additionally, this PR adds a constructor to Client that takes a jobs callback. When a callback is provided, the default jobs manager is bypassed, and instead the callback is invoked directly on the `Client.listen()` thread whenever a server event notification is received.